### PR TITLE
feat: update config to use per preset by default

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -1,5 +1,5 @@
 {
-    "preset": "psr12",
+    "preset": "per",
     "rules": {
         "align_multiline_comment": true,
         "array_indentation": true,
@@ -9,8 +9,6 @@
         "declare_parentheses": true,
         "declare_strict_types": true,
         "explicit_string_variable": true,
-        "final_class": true,
-        "final_internal_class": false,
         "fully_qualified_strict_types": true,
         "global_namespace_import": {
             "import_classes": true,


### PR DESCRIPTION
This PR updates our config to use the `per` preset by default instead of `psr12`. I've also removed the following rules:

- `final_class`
- `final_internal_class`

At this moment in time, these rules seem to be causing a few issues as it may not always be possible to set the class as `final` or `abstract`.